### PR TITLE
fix subsetting sums of feedstocks implementation to only apply equation to relevant FE carriers, sectors, markets

### DIFF
--- a/core/equations.gms
+++ b/core/equations.gms
@@ -544,11 +544,12 @@ q_emiTeDetailMkt(t,regi,enty,enty2,te,enty3,emiMkt)$(emi2te(enty,enty2,te,enty3)
           pm_emifac(t,regi,enty,enty2,te,enty3)
 		  * sum(sector$(entyFe2Sector(enty2,sector) AND sector2emiMkt(sector,emiMkt)), 
             vm_demFeSector(t,regi,enty,enty2,sector,emiMkt)
-            -vm_demFENonEnergySector(t,regi,enty,enty2,sector,emiMkt)) 
+            - sum(entyFe2sector2emiMkt_NonEn(enty2,sector,emiMkt),
+              vm_demFENonEnergySector(t,regi,enty,enty2,sector,emiMkt))
+            )
+          )
 *emissions from (non-energy) feedstocks are still missing: + vm_demFENonEnergySector(ttot,regi,entySE,entyFE,sector,emiMkt)*pm_emifacFeedstock(..)
     )
-	)
-
 ;
 
 ***--------------------------------------------------
@@ -615,9 +616,11 @@ q_emiAllMkt(t,regi,emi,emiMkt)..
 *** Exogenous emissions
   +	pm_emiExog(t,regi,emi)$(sameas(emiMkt,"other"))
 *ADD here non energy emi fro chem sector:
-  + sum(sector$sector2emiMkt(sector,emiMkt), sum(se2fe(entySe,entyFe,te), 
-       vm_demFENonEnergySector(t,regi,entySe,entyFe,sector,emiMkt)*pm_emifacNonEnergy(t,regi,entySe,entyFe,sector,emi)
-    ))
+  + sum((entyFe2sector2emiMkt_NonEn(entyFe,sector,emiMkt), 
+        se2fe(entySe,entyFe,te)), 
+      vm_demFENonEnergySector(t,regi,entySe,entyFe,sector,emiMkt)
+       * pm_emifacNonEnergy(t,regi,entySe,entyFe,sector,emi)
+    )
 ;
 
 

--- a/core/sets.gms
+++ b/core/sets.gms
@@ -2077,6 +2077,14 @@ macSector2emiMkt(all_enty,all_emiMkt)  "mapping mac sectors to emission markets"
         co2luc.other
         co2cement_process.ETS
 /
+
+entyFe2sector2emiMkt_NonEn(all_enty,emi_sectors,all_emiMkt)                     "combinations of FE type, sector and emissions markets existing for FE non-energy use"
+/
+        fesos.indst.ETS
+        fehos.indst.ETS
+        fegas.indst.ETS
+/
+
 ccsCo2(all_enty)    "only cco2 (???)"
 /
         cco2

--- a/modules/37_industry/subsectors/declarations.gms
+++ b/modules/37_industry/subsectors/declarations.gms
@@ -29,6 +29,9 @@ Parameters
   o37_shIndFE(ttot,all_regi,all_enty,secInd37,all_emiMkt)                            "share of subsector in FE industry energy carriers and emissions markets"
   o37_demFeIndSub(ttot,all_regi,all_enty,all_enty,secInd37,all_emiMkt)    "FE demand per industry subsector"
   o37_demFeIndSub_SecCC(ttot,all_regi,secInd37)           "FE per subsector whose emissions can be captured, helper parameter for calculation of industry captured CO2"
+
+  p37_FE_noNonEn(ttot,all_regi,all_enty,all_enty2,emiMkt) "testing parameter for FE without non-energy use" 
+  p37_Emi_ChemProcess(ttot,all_regi,all_enty,emiMkt)           "testing parameter for process emissions from chemical feedstocks"
 ;
 
 $ifThen.CESMkup not "%cm_CESMkup_ind%" == "standard" 

--- a/modules/37_industry/subsectors/equations.gms
+++ b/modules/37_industry/subsectors/equations.gms
@@ -133,7 +133,7 @@ q37_chemicals_feedstocks_limit(t,regi)$( t.val ge cm_startyear ) ..
 ;
 *Correction factor for non-energy feedstock emissions
 q37_demFeFeedstockChemIndst(ttot,regi,entyFe,emiMkt)$(    ttot.val ge cm_startyear 
-                                                      AND entyFe2Sector(entyFe,"indst") ) .. 
+                                                      AND entyFe2sector2emiMkt_NonEn(entyFe,"indst",emiMkt) ) .. 
  
   sum(se2fe(entySE,entyFE,te),
 

--- a/modules/37_industry/subsectors/postsolve.gms
+++ b/modules/37_industry/subsectors/postsolve.gms
@@ -59,5 +59,26 @@ pm_IndstCO2Captured(ttot,regi,entySe,entyFe,secInd37,emiMkt)$(
   / o37_demFeIndSub_SecCC(ttot,regi,secInd37);
 
 
+
+display vm_demFENonEnergySector.l;
+
+*** to be deleted before merge of feedstocks implementation, just checking the values
+*** check FE w/o non-energy use calculation
+p37_FE_noNonEn(t,regi,enty,enty2,emiMkt) = 		  
+          sum(sector$(entyFe2Sector(enty2,sector) AND sector2emiMkt(sector,emiMkt)), 
+            vm_demFeSector.l(t,regi,enty,enty2,sector,emiMkt)
+            - sum(entyFe2sector2emiMkt_NonEn(enty2,sector,emiMkt),
+              vm_demFENonEnergySector.l(t,regi,enty,enty2,sector,emiMkt)));
+
+
+*** check chemical process emissions calculation
+p37_Emi_ChemProcess(t,regi,emi,emiMkt) =
+    sum((entyFe2sector2emiMkt_NonEn(entyFe,sector,emiMkt), 
+        se2fe(entySe,entyFe,te)), 
+      vm_demFENonEnergySector.l(t,regi,entySe,entyFe,sector,emiMkt)
+       * pm_emifacNonEnergy(t,regi,entySe,entyFe,sector,emi)
+    );
+
+
 *** EOF ./modules/37_industry/subsectors/postsolve.gms
 


### PR DESCRIPTION
This applies the sums over ``vm_demFENonEnergySector`` in the emissions equations ``q_emiTeDetailMkt`` and ``q_emiAllMkt`` only to combinations of FE carriers, sectors and markets that are relevant for feedstocks and constrained by ``q37_demFeFeedstockChemIndst``. To avoid that variables become infinite/solution unbounded. 

Also some diagnostic parameters added to check FE without non-energy and resulting process emissions. Can be deleted later on. 

Test run is here: ``/p/tmp/schreyer/Modeling/REMIND_H12/NewDev/output/Base_feedstocks_2022-02-17_14.37.07``. 

I would proceed using the ``fulldata.gdx`` of this run to prepare the reporting adaptations for the feedstocks implementation in parallel to your developments here. 

