### PR TITLE
Feedstocks emissions

### DIFF
--- a/core/datainput.gms
+++ b/core/datainput.gms
@@ -1414,17 +1414,17 @@ pm_emifac(ttot,regi,"seliqfos","fedie","tdfosdie","co2") = p_ef_dem(regi,"fedie"
 
 *** define non-energy emission factors. For now only for the chemicals industry
 
-pm_emifacNonEnergy(t,regi,'segafos','fegas','indst','co2') = 0.051; !! GtC/TWa
-pm_emifacNonEnergy(t,regi,'seliqfos','fehos','indst','co2') = 0.069; !! GtC/TWa
-pm_emifacNonEnergy(t,regi,'sesofos','fesos','indst','co2') = 0.086; !! GtC/TWa
+pm_emifacNonEnergy(ttot,regi,'segafos','fegas','indst','co2') = 0.051; !! GtC/TWa
+pm_emifacNonEnergy(ttot,regi,'seliqfos','fehos','indst','co2') = 0.069; !! GtC/TWa
+pm_emifacNonEnergy(ttot,regi,'sesofos','fesos','indst','co2') = 0.086; !! GtC/TWa
 
-pm_emifacNonEnergy('2005',regi,'segafos','fegas','indst','co2') = 0.068; !! GtC/TWa
-pm_emifacNonEnergy('2005',regi,'seliqfos','fehos','indst','co2') = 0.092; !! GtC/TWa
-pm_emifacNonEnergy('2005',regi,'sesofos','fesos','indst','co2') = 0.114; !! GtC/TWa
+pm_emifacNonEnergy("2005",regi,'segafos','fegas','indst','co2') = 0.068; !! GtC/TWa
+pm_emifacNonEnergy("2005",regi,'seliqfos','fehos','indst','co2') = 0.092; !! GtC/TWa
+pm_emifacNonEnergy("2005",regi,'sesofos','fesos','indst','co2') = 0.114; !! GtC/TWa
 
-pm_emifacNonEnergy('2010',regi,'segafos','fegas','indst','co2') = 0.071; !! GtC/TWa
-pm_emifacNonEnergy('2010',regi,'seliqfos','fehos','indst','co2') = 0.096; !! GtC/TWa
-pm_emifacNonEnergy('2010',regi,'sesofos','fesos','indst','co2') = 0.119; !! GtC/TWa
+pm_emifacNonEnergy("2010",regi,'segafos','fegas','indst','co2') = 0.071; !! GtC/TWa
+pm_emifacNonEnergy("2010",regi,'seliqfos','fehos','indst','co2') = 0.096; !! GtC/TWa
+pm_emifacNonEnergy("2010",regi,'sesofos','fesos','indst','co2') = 0.119; !! GtC/TWa
 
 *** some balances are not matching by small amounts;
 *** the differences are cancelled out here!!!

--- a/modules/37_industry/subsectors/equations.gms
+++ b/modules/37_industry/subsectors/equations.gms
@@ -43,9 +43,12 @@ q37_macBaseInd(ttot,regi,entyFE,secInd37)$( ttot.val ge cm_startyear ) ..
   vm_macBaseInd(ttot,regi,entyFE,secInd37)
   =e=
     sum((secInd37_2_pf(secInd37,ppfen_industry_dyn37(in)),fe2ppfen(entyFE,in))$(entyFeCC37(entyFe)),
-      vm_cesIO(ttot,regi,in)
-    * sum((entySe,te)$(se2fe(entySe,entyFe,te) and entySeFos(entySe)), pm_emifac(ttot,regi,entySe,entyFe,te,"co2"))
-    )
+      (vm_cesIO(ttot,regi,in)
+      - p37_chemicals_feedstock_share(ttot,regi)
+      * vm_cesIO(ttot,regi,in)$(in_chemicals_37(in)))
+    * sum((entySe,te)$(se2fe(entySe,entyFe,te) and entySeFos(entySe)),
+        pm_emifac(ttot,regi,entySe,entyFe,te,"co2"))
+        )
 ;
 
 *' Compute maximum possible CCS level in industry sub-sectors given the current


### PR DESCRIPTION

* initialize pm_emifacNonEnergy assignment before ``cm_startyear``, needed for reporting such that this parameter is non-zero for first years
* remove feedstock carbon from carbon that can be captured in industry ``vm_macBaseInd``